### PR TITLE
Add extractor for opening span from the message injected span

### DIFF
--- a/opentracing-pulsar-client/src/main/java/io/streamnative/pulsar/tracing/MessagePropertiesExtractAdapterAfterConsume.java
+++ b/opentracing-pulsar-client/src/main/java/io/streamnative/pulsar/tracing/MessagePropertiesExtractAdapterAfterConsume.java
@@ -1,0 +1,40 @@
+package io.streamnative.pulsar.tracing;
+
+import io.opentracing.propagation.TextMap;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.impl.MessageImpl;
+import org.apache.pulsar.client.impl.TopicMessageImpl;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+public class MessagePropertiesExtractAdapterAfterConsume implements TextMap {
+  private final Map<String, String> map = new HashMap<>();
+
+  public MessagePropertiesExtractAdapterAfterConsume(Message<?> message) {
+    MessageImpl<?> msg = null;
+
+    if (message instanceof MessageImpl<?>) {
+      msg = (MessageImpl<?>) message;
+
+    } else if (message instanceof TopicMessageImpl<?>) {
+      msg = (MessageImpl<?>) ((TopicMessageImpl<?>) message).getMessage();
+    }
+
+    if (msg != null) {
+      msg.getMessageBuilder().getPropertiesList().forEach(kv -> map.put(kv.getKey(), kv.getValue()));
+    }
+  }
+
+  @Override
+  public Iterator<Map.Entry<String, String>> iterator() {
+    return map.entrySet().iterator();
+  }
+
+  @Override
+  public void put(String key, String value) {
+    throw new UnsupportedOperationException(
+            "MessagePropertiesExtractAdapter should only be used with Tracer.extract()");
+  }
+}


### PR DESCRIPTION
Injected Trace info is not available in the message properties after consuming a message,  as such, it is not possible to create a new span that follows from the injected span after consuming the message.

I added an extractor adapter that enables us to extract trace info from the message builder.